### PR TITLE
Fix for a ImmutableIntArrayDocIdSet bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ivy
 lib
 build-test
 SerialDocSet
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.linkedin.kamikaze</groupId>
   <artifactId>kamikaze</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.6</version>
+  <version>3.0.7-SNAPSHOT</version>
   <name>kamikaze</name>
   <description>information retrival utility package for enhancing Lucene</description>
   <url>http://sna-projects.com/kamikaze</url>

--- a/src/main/java/com/kamikaze/docidset/impl/ImmutableIntArrayDocIdSet.java
+++ b/src/main/java/com/kamikaze/docidset/impl/ImmutableIntArrayDocIdSet.java
@@ -56,12 +56,12 @@ public class ImmutableIntArrayDocIdSet extends DocIdSet {
       if (cursor >= _array.length || _array.length == -1) return DocIdSetIterator.NO_MORE_DOCS;
       if (target <= _doc) target = _doc + 1;      
       int index = Arrays.binarySearch(_array, target);
-      if (index > 0){
+      if (index >= 0) {
         cursor = index;
         _doc = _array[cursor];
         return _doc;
       }
-      else{
+      else {
         cursor = -(index+1);
         if (cursor>=_array.length) {
           _doc = DocIdSetIterator.NO_MORE_DOCS;

--- a/src/test/java/com/kamikaze/test/PForDeltaTestKamikazeTest.java
+++ b/src/test/java/com/kamikaze/test/PForDeltaTestKamikazeTest.java
@@ -172,18 +172,20 @@ ArrayList<DocIdSet>();
       
       @Test 
       public void testImmutableSet() throws IOException{ 
-              int[] data = new int[]{20,30,40}; 
+              int[] data = new int[]{10,20,30,40}; 
               ImmutableIntArrayDocIdSet dsImmutable = new 
               ImmutableIntArrayDocIdSet(data); 
               IntArrayDocIdSet dsRegular = new IntArrayDocIdSet(); 
               dsRegular.addDocs(data, 0, data.length); 
               DocIdSetIterator dsImmutableIt = dsImmutable.iterator(); 
-              DocIdSetIterator dsRegualIt = dsRegular.iterator(); 
-              assertEquals(20, dsRegualIt.advance(0));  
-              assertEquals(20, dsImmutableIt.advance(0));
-              assertEquals(30, dsRegualIt.advance(29));
+              DocIdSetIterator dsRegularIt = dsRegular.iterator(); 
+              assertEquals(10, dsRegularIt.advance(10));  
+              assertEquals(10, dsImmutableIt.advance(10));
+              assertEquals(20, dsRegularIt.advance(15));  
+              assertEquals(20, dsImmutableIt.advance(15));
+              assertEquals(30, dsRegularIt.advance(29));
               assertEquals(30, dsImmutableIt.advance(29));
-              assertEquals(DocIdSetIterator.NO_MORE_DOCS,dsRegualIt.advance(50));
+              assertEquals(DocIdSetIterator.NO_MORE_DOCS,dsRegularIt.advance(50));
               assertEquals(DocIdSetIterator.NO_MORE_DOCS,dsImmutableIt.advance(50));
       }
 }


### PR DESCRIPTION
Bug fixed: ArrayIndexOutOfBoundsException in ImmutableIntArrayDocIdSet.
The uncaught exception is raised when calling advance(target) when target == the first element.
