### PR TITLE
convert the encoding/decoding to be compatible to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.linkedin.kamikaze</groupId>
   <artifactId>kamikaze</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.6</version>
+  <version>3.0.7</version>
   <name>kamikaze</name>
   <description>information retrival utility package for enhancing Lucene</description>
   <url>http://sna-projects.com/kamikaze</url>
@@ -70,6 +70,7 @@
             -Xms256m -Xmx4g <!-- -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=y -->  
           </argLine>
           <excludes>
+            <exclude>com/kamikaze/lucenecode/test/*.java</exclude>
             <exclude>com/kamikaze/test/perf/*.java</exclude>
             <exclude>**/*$*</exclude>
           </excludes>

--- a/src/main/java/com/kamikaze/docidset/impl/PForDeltaDocIdSet.java
+++ b/src/main/java/com/kamikaze/docidset/impl/PForDeltaDocIdSet.java
@@ -46,7 +46,7 @@ public class PForDeltaDocIdSet extends DocSet implements Serializable {
   transient private int[] currentNoCompBlock;  // the memory used to store the uncompressed elements. Once the block is full, all its elements are compressed into sequencOfCompBlock and the block is cleared.
   transient private int sizeOfCurrentNoCompBlock = 0; // the number of uncompressed elements that is hold in the currentNoCompBlock  
   
-  private int version = 1;
+  transient private int version = 1;
   
   public PForDeltaDocIdSet() {
     sequenceOfCompBlocks = new PForDeltaIntSegmentArray();

--- a/src/test/java/com/kamikaze/test/PForDeltaKamikazeTest.java
+++ b/src/test/java/com/kamikaze/test/PForDeltaKamikazeTest.java
@@ -50,12 +50,13 @@ public class PForDeltaKamikazeTest extends TestCase
     
     int[] numArray = new int[set.size()];
     
-    //Arrays.sort(numArray);
+    
     
     int i = 0;
     for (int n : set){
       numArray[i++] = n;
     }
+    Arrays.sort(numArray);
     
     PForDeltaDocIdSet docset = new PForDeltaDocIdSet();
     


### PR DESCRIPTION
hi, john

I changed the encoding/decoding of 3.06 to be backward compatible to 3.0.1 since otherwise cloud cannot upgrade. The change won't affect the performance. Could you pull and make a release of 3.0.7-SNAPSHOT? 

thanks

hao
